### PR TITLE
added submit button id, text field value support and resetForm

### DIFF
--- a/simpleform.js
+++ b/simpleform.js
@@ -6,6 +6,9 @@ SimpleForm = {
       return form[formItem.name] = formItem.value;
     });
     return form;
+  },
+  resetForm: function(target){
+    $(target).trigger('reset')
   }
 };
 


### PR DESCRIPTION
Submit button now supports html id for targeted event handling.

```
{{submit_button "Submit" id="btnInsert" class="btn-primary btn-lg btn-block"}}
```

This is handled in helpers.js see processId function.

Text field now supports value including run time values like helpers,  methods, reactive values, etc...

```
{{text_field 'name' value="business name" label="Business Name" placeholder="Enter business name" value='Krusty Burger'}}
```

OR

```
{{text_field 'name' value="business name" label="Business Name" placeholder="Enter business name" value=getBusinessName}}
```

SimpleForm now has a resetForm method.  
