### PR TITLE
added processId to get html ids into dom and SubmitForm.resetForm method

### DIFF
--- a/helper.js
+++ b/helper.js
@@ -7,6 +7,14 @@ processClass = function(optionsHash) {
   return html_class
 }
 
+processId = function(optionsHash) {
+  if (optionsHash['id']) {
+    return " id='" + optionsHash['id'] + "'";
+  } else {
+    return ""
+  }
+}
+
 processPlaceHolder = function(optionsHash) {
   if (optionsHash['placeholder']) {
     placeholder = " placeholder='" + optionsHash['placeholder'] + "' "
@@ -214,10 +222,11 @@ Handlebars.registerHelper('submit_button', function(text, options){
   klass = _this.constructor.name;
   value = text || "Submit " + klass;
   html_class = processClass(options.hash);
+  html_id = processId(options.hash);
   if (options.hash['button']) {
-    html = "<button type='submit' class='btn btn-default"+ html_class +"'>" + value + "</button>";
+    html = "<button type='submit' class='btn btn-default"+ html_class + "'"+ html_id +">" + value + "</button>";
   } else {
-    html = "<input type='submit' value='"+ value +"' class='btn btn-default"+ html_class +"'>";
+    html = "<input type='submit' value='"+ value +"' class='btn btn-default"+ html_class + "'"+ html_id +">";
   }
   return new Handlebars.SafeString(html);
 });

--- a/simpleform.js
+++ b/simpleform.js
@@ -6,6 +6,9 @@ SimpleForm = {
       return form[formItem.name] = formItem.value;
     });
     return form;
+  },
+  resetForm: function(target){
+    $(target).trigger('reset')
   }
 };
 


### PR DESCRIPTION
Sorry about last nights PR.  It was late and I had forgotten to pull changes from upstream to get latest.

You will now see processId, implemented into submit_button and could be implemented on other form dom elements in the future.

Also included is SimpleForm.resetForm method.  I was going to make that a boolean on the processForm but that did not make sense because the form might have validation errors, etc...

BTW, whenever I install from mrt it installs an old version into projects.
