### PR TITLE
Don't add time to date value

### DIFF
--- a/simpleform.js
+++ b/simpleform.js
@@ -5,7 +5,7 @@ SimpleForm = {
     _.each(array, function(formItem) {
       type = $(target).find("input[name='" + formItem.name + "']").attr('type')
       if (type === 'date' && !!formItem.value) {
-        return form[formItem.name] = new Date(formItem.value + " 00:00");
+        return form[formItem.name] = new Date(formItem.value);
       } else {
         return form[formItem.name] = formItem.value;
       }


### PR DESCRIPTION
Normally, when creating a Date object, your browser will add a time taking into account your time zone:

```
new Date("2014-08-13")
Wed Aug 13 2014 02:00:00 GMT+0200 (CEST)
```

When you add a specific time yourself, you lose this behavior:

```
new Date("2014-08-13 00:00")
Wed Aug 13 2014 00:00:00 GMT+0200 (CEST)
```

As a result, the database could show incorrect date values as they're converted to UTC:

```
2014-08-12 22:00:00.000Z
```
